### PR TITLE
add faction fix

### DIFF
--- a/app/routes/draft.new/sections/AvailableFactionsSection.tsx
+++ b/app/routes/draft.new/sections/AvailableFactionsSection.tsx
@@ -22,7 +22,7 @@ export function AvailableFactionsSection() {
     (state) => state.draft.settings.numPreassignedFactions,
   );
   const factionPool = useDraft((state) =>
-    (state.draft.availableFactions ?? state.factionPool).filter(
+    state.factionPool.filter(
       (f: FactionId) => !state.draft.availableMinorFactions?.includes(f),
     ),
   );


### PR DESCRIPTION
Hi, i change factionPool in AvailableFactionsSection, because availableFactions are factions that already draft and we can't plus new factions during settings draft (page "draft/new").