### PR TITLE
Correct spelling of 'Resulon' to 'Resculon'

### DIFF
--- a/app/data/rawSystemData.ts
+++ b/app/data/rawSystemData.ts
@@ -448,7 +448,7 @@ export const rawSystems: Record<string, RawSystem> = {
         trait: ["CULTURAL"],
       },
       {
-        name: "Resulon",
+        name: "Resculon",
         resources: 2,
         influence: 0,
         legendary: false,


### PR DESCRIPTION
Super minor change that just fixes the name of the planet Resculon in the Corneeq/Resculon slice; it was spelled incorrectly as "Resulon" (missing the c) previously.