### PR TITLE
Change submit button color to #E9C46A

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,7 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            color="#E9C46A"
           >
             Continue
           </Button>


### PR DESCRIPTION
Update the main page submit button color from its current color to #E9C46A (golden yellow).

This change improves the visual design by using a warmer, more prominent color for the submit button.

---
Plan path: /app/fixes/plans/ti4-lab/plan-d23553ea.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 1 +
 1 file changed, 1 insertion(+)

Apply output (truncated):
```
**Summary**

Changed the submit ("Continue") button color to `#E9C46A` by adding `color="#E9C46A"` to the `Button` component in `/app/fixes/ti4-lab/app/routes/draft.prechoice/route.tsx` (line 484).

No automated tests were run — this is a purely visual change (a single prop addition to a UI component), and the project's test suite would require a full build environment to run meaningfully.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single UI styling change (adds a `color` prop) with no impact on logic, data handling, or navigation flow.
> 
> **Overview**
> Updates the primary **Continue** CTA on the draft prechoice page to use the explicit Mantine `Button` color `#E9C46A`, changing only the button’s appearance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abd17b2b1ee67744b465ff5708edb13a0e7d9aec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->