### PR TITLE
Change submit button color to #E63946

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,8 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            color="#E63946"
+            variant="filled"
           >
             Continue
           </Button>


### PR DESCRIPTION
Updates the main page submit button color to #E63946 (red) for improved visual styling.

---
Plan path: /app/fixes/plans/ti4-lab/plan-df295e3f.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 2 ++
 1 file changed, 2 insertions(+)

Apply output (truncated):
```
Dependencies aren't installed. The change is straightforward — Mantine's `Button` component accepts a `color` prop with hex values and a `variant` prop. The `color="#E63946"` with `variant="filled"` overrides the default gradient. No TypeScript errors are expected since these are valid Mantine Button props.

---

**Summary**

Changed the "Continue" submit button on the main page (`app/routes/draft.prechoice/route.tsx:479`) from the default purple-to-indigo gradient to solid red `#E63946` by adding:
- `color="#E63946"` — sets the button color to the specified red
- `variant="filled"` — overrides the global default `variant="gradient"` so the solid color is used

**Tests run:** Attempted TypeScript typecheck (`tsc --noEmit`) but node_modules are not installed in the environment. The change uses standard Mantine `Button` props (`color` and `variant`) which accept these values per Mantine's API — no type errors expected.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks Mantine `Button` styling; no logic or data flow is modified.
> 
> **Overview**
> Updates the primary "Continue" CTA on `draft.prechoice` to render as a solid red button by explicitly setting `color="#E63946"` and `variant="filled"` (instead of inheriting default styling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee1d90cc7fbff4ae6dda97431cf4c90f01d1bcb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->