### PR TITLE
Change submit button color to #264653

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,8 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            color="#264653"
+            variant="filled"
           >
             Continue
           </Button>


### PR DESCRIPTION
Update the main page submit button color to #264653 for improved visual design.

---
Plan path: /app/fixes/plans/ti4-lab/plan-ffbcb18d.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 2 ++
 1 file changed, 2 insertions(+)

Apply output (truncated):
```
No `node_modules` are installed in this environment. The TypeScript type check can't run, but the change is straightforward.

---

**Summary of changes:**

- **File:** `app/routes/draft.prechoice/route.tsx` (line 484-485)
- Added `color="#264653"` and `variant="filled"` to the "Continue" submit button, overriding the global gradient theme to display the button in solid `#264653` (dark teal/green).

**Tests run:**
- Attempted `npm run typecheck` — failed because `node_modules` are not installed in this environment. The change itself is type-safe: `color` accepts any valid CSS color string in Mantine's `Button` component, and `variant="filled"` is a standard Mantine variant.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely visual change to a single Mantine `Button` prop set; no logic, routing, or data handling behavior is modified.
> 
> **Overview**
> Updates the primary "Continue" CTA on `draft.prechoice` to render as a solid filled button by explicitly setting `color="#264653"` and `variant="filled"`, overriding any theme/default styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfc9fde6f7e349fdae45ac1f6495d952556d0d67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->