### PR TITLE
Change submit button color to #6BCB77

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,8 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            variant="filled"
+            color="#6BCB77"
           >
             Continue
           </Button>


### PR DESCRIPTION
Updates the main page submit button color from the current color to #6BCB77 (green) for better visual appeal and consistency with design requirements.

---
Plan path: /app/fixes/plans/ti4-lab/plan-93cf51df.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 2 ++
 1 file changed, 2 insertions(+)

Apply output (truncated):
```
**Summary**

Changed the main page submit ("Continue") button color to `#6BCB77` (green) in `/app/fixes/ti4-lab/app/routes/draft.prechoice/route.tsx` (line 479).

- Added `variant="filled"` to override the default gradient variant (Mantine requires `filled` for hex color support)
- Added `color="#6BCB77"` to set the green color

No automated tests were run as this is a visual/CSS change with no testable logic. The change is minimal and isolated to the button component props.
```
