### PR TITLE
Change submit button color to #00C9A7

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,8 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            variant="filled"
+            color="#00C9A7"
           >
             Continue
           </Button>


### PR DESCRIPTION
Updates the main page submit button color from the current styling to #00C9A7 (teal green).

This change improves the visual appearance and aligns with the requested color scheme.

---
Plan path: /app/fixes/plans/ti4-lab/plan-b43fae22.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 2 ++
 1 file changed, 2 insertions(+)

Apply output (truncated):
```
**Summary**

Changed the main page "Continue" submit button color to `#00C9A7` (teal green) in `/app/fixes/ti4-lab/app/routes/draft.prechoice/route.tsx` (line 479-488).

- Added `variant="filled"` to override the default gradient variant
- Added `color="#00C9A7"` to set the teal green color

**Tests run**: None (node_modules not installed, TypeScript compiler unavailable). The change is minimal and syntactically straightforward — only two props added to a Mantine `Button` component with a valid hex color value.
```
