### PR TITLE
Change submit button color to #F9F871

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,8 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            variant="filled"
+            color="#F9F871"
           >
             Continue
           </Button>


### PR DESCRIPTION
Updates the main page submit button color to #F9F871 as requested.

This change modifies the submit button styling to use the specified color value.

---
Plan path: /app/fixes/plans/ti4-lab/plan-d4d39fc9.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 2 ++
 1 file changed, 2 insertions(+)

Apply output (truncated):
```
No package manager available in this environment. The change is straightforward — adding `variant="filled"` and `color="#F9F871"` props to a Mantine `Button` component, which are valid Mantine v7 props accepting hex color strings.

---

**Summary**

Changed the main page submit button ("Continue") in `app/routes/draft.prechoice/route.tsx:479` to use color `#F9F871`:

- Added `variant="filled"` to override the default gradient variant
- Added `color="#F9F871"` to apply the requested yellow color

**Tests run:** Attempted TypeScript type-check (`tsc --noEmit`) but no package manager/node_modules were available in the environment. The change is minimal and type-safe — Mantine's `Button` `color` prop accepts hex strings and `variant` accepts `"filled"`.
```
