### PR TITLE
Change submit button color to #008F7A

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,7 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            gradient={{ from: "#008F7A", to: "#008F7A", deg: 90 }}
           >
             Continue
           </Button>


### PR DESCRIPTION
Updates the main page submit button color to #008F7A as requested.

This change modifies the styling of the submit button to use the new teal color scheme.

---
Plan path: /app/fixes/plans/ti4-lab/plan-97e9d45d.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 1 +
 1 file changed, 1 insertion(+)

Apply output (truncated):
```
**Summary**

Changed the "Continue" submit button on the main page (`app/routes/draft.prechoice/route.tsx:484`) to use color `#008F7A` by adding `gradient={{ from: "#008F7A", to: "#008F7A", deg: 90 }}`. This overrides the theme's default purple-to-indigo gradient with the requested teal color.

**Tests run:** TypeScript compiler was not installed in the environment, so type checking could not run. The change follows Mantine's standard `gradient` prop API for `<Button>` and is syntactically correct.
```
