### PR TITLE
Change submit button color to #FFC75F

### DIFF
--- a/app/ui/buttons.module.css
+++ b/app/ui/buttons.module.css
@@ -4,6 +4,9 @@
     letter-spacing: 0.03em;
     text-transform: uppercase;
     transition: all 0.15s ease;
+    background: #FFC75F;
+    --button-bg: #FFC75F;
+    --button-hover-color: #FFC75F;
 }
 
 @mixin light {


### PR DESCRIPTION
Update the main page submit button color to #FFC75F as requested.

This PR changes the submit button styling to use the specified color value.

---
Plan path: /app/fixes/plans/ti4-lab/plan-709df528.md

Diff stat:
app/ui/buttons.module.css | 3 +++
 1 file changed, 3 insertions(+)

Apply output (truncated):
```
TypeScript isn't installed locally. The CSS change is straightforward with no TS implications.

---

**Summary**

Changed the submit button color to `#FFC75F` by updating `/app/fixes/ti4-lab/app/ui/buttons.module.css`.

The main page's "Continue" button on `/draft/prechoice` uses the `.primaryCta` CSS class. I added three properties to override Mantine's default gradient styling:
- `background: #FFC75F` — direct CSS background override
- `--button-bg: #FFC75F` — Mantine CSS variable for button background
- `--button-hover-color: #FFC75F` — Mantine CSS variable for hover state

**Tests run:** None automated (TypeScript not installed in the environment; the change is CSS-only with no logic implications).
```
