### PR TITLE
Change submit button color to #D65DB1

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,7 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            gradient={{ from: "#D65DB1", to: "#D65DB1", deg: 90 }}
           >
             Continue
           </Button>


### PR DESCRIPTION
Updates the main page submit button color to #D65DB1 as requested.

This PR changes the submit button styling to use the new pink/magenta color scheme.

---
Plan path: /app/fixes/plans/ti4-lab/plan-4aadb2f5.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 1 +
 1 file changed, 1 insertion(+)

Apply output (truncated):
```
No node_modules available to run type-checking, but the change is minimal and straightforward. The Mantine v8 `Button` component accepts a `gradient` prop with `{ from: string, to: string, deg?: number }` type, and hex strings are valid color values.

---

**Summary of changes:**

**File modified:** `app/routes/draft.prechoice/route.tsx` (line 484)

Added `gradient={{ from: "#D65DB1", to: "#D65DB1", deg: 90 }}` to the "Continue" submit button, overriding the default purple-to-indigo gradient defined in the Mantine theme. This sets the button color to `#D65DB1` (pink/magenta).

**Tests run:** TypeScript compiler not available (no node_modules installed), but the change is a single-prop addition using the standard Mantine v8 `Button` gradient API — no logic changes, no risk of runtime errors.
```
