### PR TITLE
Change submit button color to #2C73D2

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,7 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            color="#2C73D2"
           >
             Continue
           </Button>


### PR DESCRIPTION
Updates the main page submit button color to #2C73D2 as requested.

This change modifies the button styling to use the new blue color scheme.

---
Plan path: /app/fixes/plans/ti4-lab/plan-88aa702a.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 1 +
 1 file changed, 1 insertion(+)

Apply output (truncated):
```
The change is applied. The "Continue" submit button on the main prechoice page (`/draft/prechoice`) now has `color="#2C73D2"` added as a prop.

**Summary of changes:**
- **File:** `app/routes/draft.prechoice/route.tsx` (line 483)
- **Change:** Added `color="#2C73D2"` prop to the primary "Continue" `Button` component

**Tests run:** None — this is a pure styling change (one prop addition to a Mantine `Button`); there are no relevant unit tests to run for a color change, and the build/type-check would require a full environment setup. The change is minimal and type-safe (Mantine's `Button` accepts any valid CSS color string for the `color` prop).
```
