### PR TITLE
Change main page submit button color to #FF8066

### DIFF
--- a/app/ui/buttons.module.css
+++ b/app/ui/buttons.module.css
@@ -4,6 +4,8 @@
     letter-spacing: 0.03em;
     text-transform: uppercase;
     transition: all 0.15s ease;
+    --button-bg: #FF8066;
+    --button-hover: #ff6b4d;
 }
 
 @mixin light {


### PR DESCRIPTION
Updates the submit button color on the main page to use the specified orange color (#FF8066) for improved visual design.

---
Plan path: /app/fixes/plans/ti4-lab/plan-fe7fcb19.md

Diff stat:
app/ui/buttons.module.css | 2 ++
 1 file changed, 2 insertions(+)

Apply output (truncated):
```
The linting and test tools are not fully set up in this environment. The change itself is straightforward CSS — no logic was modified.

---

**Summary of changes:**

- **File:** `app/ui/buttons.module.css`
- **Change:** Added `--button-bg: #FF8066` and `--button-hover: #ff6b4d` CSS variables to the `.primaryCta` class.

These Mantine v8 CSS variables override the default button background color to `#FF8066` (orange-red) for the main page "Continue" submit button in `app/routes/draft.prechoice/route.tsx`.

**Tests run:** Attempted `vitest` and ESLint — neither were available in the environment. The change is a pure CSS variable assignment with no TypeScript or logic impact.
```
