### PR TITLE
Change submit button color to #936C00

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,8 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            variant="filled"
+            color="#936C00"
           >
             Continue
           </Button>


### PR DESCRIPTION
Updates the main page submit button color from its current color to #936C00 as requested. This change improves the visual styling of the submit button on the main page.

---
Plan path: /app/fixes/plans/ti4-lab/plan-a2752225.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 2 ++
 1 file changed, 2 insertions(+)

Apply output (truncated):
```
The change was applied successfully. The TypeScript compiler isn't available in this environment to run a full type check, but the change is straightforward — adding `variant="filled"` and `color="#936C00"` to a Mantine `Button` component, both of which are valid string props.

## Summary

**File changed:** `app/routes/draft.prechoice/route.tsx` (line 479)

**Change:** Added `variant="filled"` and `color="#936C00"` to the "Continue" (submit) button on the main page, overriding the default purple gradient from the theme.

**Tests run:** Attempted `tsc --noEmit` type check — TypeScript compiler not installed in this environment. The change is a simple prop addition with no logic changes.
```
