### PR TITLE
Change submit button color to #4B4453

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,7 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            color="#4B4453"
           >
             Continue
           </Button>


### PR DESCRIPTION
Updates the main page submit button color from the current color to #4B4453 as requested. This change improves the visual styling of the submit button on the main page.

---
Plan path: /app/fixes/plans/ti4-lab/plan-8c0fa3b9.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 1 +
 1 file changed, 1 insertion(+)

Apply output (truncated):
```
**Summary**

Changed the submit ("Continue") button color on the main page (`app/routes/draft.prechoice/route.tsx:484`) by adding `color="#4B4453"` to the Mantine `Button` component that uses the `primaryCta` class.

No automated tests were run, as this is a pure UI color change with no logic implications.
```
