### PR TITLE
Change submit button color to #F4A261

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,8 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            color="#F4A261"
+            variant="filled"
           >
             Continue
           </Button>


### PR DESCRIPTION
Update the main page submit button color to #F4A261 for improved visual design.

Changes:
- Locate the main page submit button component
- Update the color styling to use #F4A261
- Ensure the color change is applied consistently across the button states

---
Plan path: /app/fixes/plans/ti4-lab/plan-863fb4dc.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 2 ++
 1 file changed, 2 insertions(+)

Apply output (truncated):
```
TypeScript is not installed locally. The change itself is straightforward — Mantine's `Button` component accepts `color` as a CSS color string (including hex values) and `variant` as a string, so there are no type issues.

---

**Summary**

Updated the main page "Continue" submit button in `app/routes/draft.prechoice/route.tsx:479-488` to use `#F4A261`:
- Added `color="#F4A261"` to set the button background to the requested color
- Added `variant="filled"` to override the default gradient variant from the theme, ensuring the solid color is applied consistently (including hover/active states via Mantine's automatic shade generation)

**Tests run:** TypeScript compiler not available locally; the change is minimal and type-safe (both `color` and `variant` are standard Mantine `Button` string props).
```
