### PR TITLE
Change submit button color to #E9C46A

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,8 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            color="#E9C46A"
+            variant="filled"
           >
             Continue
           </Button>


### PR DESCRIPTION
Updates the main page submit button color from the current color to #E9C46A (golden yellow).

This change improves the visual design by using a warmer, more prominent color for the submit button.

---
Plan path: /app/fixes/plans/ti4-lab/plan-ef28f02c.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 2 ++
 1 file changed, 2 insertions(+)

Apply output (truncated):
```
Dependencies aren't installed in this environment, so I can't run the TypeScript compiler. The change is straightforward — Mantine's `Button` component accepts `color` as a CSS hex string and `variant="filled"` is a standard prop. The types are valid.

---

**Summary**

Changed the submit ("Continue") button on the main page in `app/routes/draft.prechoice/route.tsx` (lines 479-487):

- Added `color="#E9C46A"` to set the golden yellow color
- Added `variant="filled"` to override the default gradient variant and display the solid color

**Tests run:** Attempted TypeScript type check — `node_modules` not installed in this environment, so the compiler wasn't available. The change is a simple prop addition using standard Mantine v7 Button API (`color` accepts CSS color strings, `variant="filled"` is a built-in variant).
```
