### PR TITLE
Change submit button color to #2A9D8F

### DIFF
--- a/app/routes/draft.prechoice/route.tsx
+++ b/app/routes/draft.prechoice/route.tsx
@@ -481,6 +481,7 @@ export default function DraftPrechoice() {
             onMouseDown={handleContinue}
             leftSection={<IconPlayerPlay />}
             className={buttonClasses.primaryCta}
+            style={{ backgroundColor: "#2A9D8F" }}
           >
             Continue
           </Button>


### PR DESCRIPTION
Updates the main page submit button color from its current styling to #2A9D8F (teal green) for improved visual design.

---
Plan path: /app/fixes/plans/ti4-lab/plan-9fc734f2.md

Diff stat:
app/routes/draft.prechoice/route.tsx | 1 +
 1 file changed, 1 insertion(+)

Apply output (truncated):
```
The change is straightforward — `style={{ backgroundColor: "#2A9D8F" }}` is valid React/TypeScript syntax for a Mantine `Button` component. The type check tooling isn't available in this environment, but the change is syntactically correct.

---

**Summary**

Changed the main page "Continue" submit button color to `#2A9D8F` (teal green).

**File modified:** `app/routes/draft.prechoice/route.tsx:484`

Added `style={{ backgroundColor: "#2A9D8F" }}` to the `<Button>` component that serves as the primary CTA on the main draft setup page.

**Tests run:** Attempted TypeScript type check (`tsc --noEmit`) — tooling not installed in this environment, but the change is a straightforward inline style addition with no type concerns.
```
