### PR TITLE
Fix snake draft order resetting per ring in Texas tile placement

### DIFF
--- a/app/utils/draftOrder.server.ts
+++ b/app/utils/draftOrder.server.ts
@@ -110,9 +110,8 @@ export function createDraftOrder({
 
     if (presetMap) {
       const ringCounts = getTexasRingPickCounts(presetMap);
-      ringCounts.forEach((count) => {
-        pickOrder.push(...generateSnakeOrder(seatOrder, count));
-      });
+      const totalTiles = ringCounts.reduce((sum, c) => sum + c, 0);
+      pickOrder.push(...generateSnakeOrder(seatOrder, totalTiles));
     }
 
     return {


### PR DESCRIPTION
In `app/utils/draftOrder.server.ts`, `generateSnakeOrder` was called 
separately for each map ring, causing the snake direction to reset to 
"forward" at the start of every ring instead of continuing from where 
the previous ring left off.

**Fix:** call `generateSnakeOrder` once with the total tile count across 
all rings instead of once per ring.

Before:
```typescript
ringCounts.forEach((count) => {
  pickOrder.push(...generateSnakeOrder(seatOrder, count));
});
```

After:
```typescript
const totalTiles = ringCounts.reduce((sum, c) => sum + c, 0);
pickOrder.push(...generateSnakeOrder(seatOrder, totalTiles));
```